### PR TITLE
[YUNIKORN-5] Change the contribution guide and add .asf.yaml for github

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,9 @@
+github:
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+  features:
+    wiki: true
+    issues: false
+    projects: false

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,16 +1,26 @@
 # How do I contribute code?
-You need to first sign and return an [Individual Contributor License Agreement (ICLA)](https://github.com/cloudera/yunikorn-core/blob/master/CLAs/Cloudera%20ICLA_25APR2018.pdf) before we can accept and redistribute your contribution. Please sign and submit to CLA@cloudera.com. When you sign the ICLA document, field **Facsimile** is optional and you can leave it blank.
+The scheduler interface specification provides the definition for the communication between
+different components in YuniKorn. Changes in the interface have flow on effects in all other
+components.
 
-**IMPORTANT**: Note that you may need to discuss with your employer before signing the ICLA, because your employer may ask you to contribute under your employment role. In this case, you need to sign a [Corporate Contributor License Agreement (CCLA)](https://github.com/cloudera/yunikorn-core/blob/master/CLAs/Cloudera%20CCLA_25APR2018.pdf).
+Changes in the interface specification will be highly scrutinised and are not really
+suited as a simple start to become familiar with YuniKorn. 
 
 ### Find
-We use Github issues to track bugs for this project. Find an issue that you would like to
+We use JIRA issues to track bugs for this project. Find an issue that you would like to
 work on (or file one if you have discovered a new issue!). If no-one is working on it,
 assign it to yourself only if you intend to work on it shortly.
+The easiest way to get started working with the code base is to pick up a really easy
+JIRA and work on that. This will help you get familiar with the code base, build system,
+review process, etc. We flag these kind of starter bugs
+[here](https://issues.apache.org/jira/issues/?jql=project%3DYUNIKORN%20AND%20status%3DOpen%20AND%20labels%3Dnewbie).
 
 It’s a good idea to discuss your intended approach on the issue. You are much more
 likely to have your patch reviewed and committed if you’ve already got buy-in from the
-yunikorn community before you start.
+YuniKorn community before you start.
+
+If you cannot assign the JIRA to yourself ask the community to help assign it and add you
+to the contributors list in JIRA.   
 
 ### Fix
 Now start coding! As you are writing your patch, please keep the following things in mind:
@@ -26,8 +36,14 @@ check if you can assign it to yourself and fix it independently of the feature. 
 us to differentiate between bug fixes and features and allows us to build stable
 maintenance releases.
 
+Make sure you have observed the recommendations in the coding guidelines.
+
 Finally, please write a good, clear commit message, with a short, descriptive title and
 a message that is exactly long enough to explain what the problem was, and how it was
 fixed.
 
 Please create a pull request on github with your patch.
+
+The pull request description should include the JIRA reference that you are working on.
+For example a pull request linked to [YUNIKORN-2](https://issues.apache.org/jira/browse/YUNIKORN-2) should have a description like:
+`[YUNIKORN-2] Gang scheduling interface parameters`


### PR DESCRIPTION
Updating the contribution guide to remove the last references to Cloudera.
Adding a new .asf.yaml file to turn off github issues.