### PR TITLE
[YUNIKORN-128] Add license headers in scheduler-interface

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 github:
   enabled_merge_buttons:
     squash:  true

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,16 @@ build: $(SI_PROTO).tmp $(CONSTANTS_GO).tmp
 test:
 	@echo ""
 
+# Check for missing license headers
+.PHONY: check-license
+check-license:
+	@echo "checking license header"
+	@licRes=$$(grep -Lr --exclude-dir=lib --include=*.{go,sh,md,yaml,mod} "Licensed to the Apache Software Foundation" .) ; \
+	if [ -n "$${licRes}" ]; then \
+		echo "following files have incorrect license header:\n$${licRes}" ; \
+		exit 1; \
+	fi
+
 # Simple clean of generated files only (no local cleanup).
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
 # Yunikorn Scheduler Interface
 Yunikorn Scheduler Interface defines protobuf interfaces for the communication between the yunikorn-core and the resource management systems.
 

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,10 +1,28 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
 # How do I contribute code?
 The scheduler interface specification provides the definition for the communication between
 different components in YuniKorn. Changes in the interface have flow on effects in all other
 components.
 
 Changes in the interface specification will be highly scrutinised and are not really
-suited as a simple start to become familiar with YuniKorn. 
+suited as a simple start to become familiar with YuniKorn.
 
 ### Find
 We use JIRA issues to track bugs for this project. Find an issue that you would like to
@@ -20,7 +38,7 @@ likely to have your patch reviewed and committed if you’ve already got buy-in 
 YuniKorn community before you start.
 
 If you cannot assign the JIRA to yourself ask the community to help assign it and add you
-to the contributors list in JIRA.   
+to the contributors list in JIRA.
 
 ### Fix
 Now start coding! As you are writing your patch, please keep the following things in mind:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,22 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
 module github.com/apache/incubator-yunikorn-scheduler-interface
 
 go 1.12

--- a/scheduler-interface-spec.md
+++ b/scheduler-interface-spec.md
@@ -1,3 +1,21 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
 # Scheduler Interface Spec
 
 Authors: The Yunikorn Scheduler Authors


### PR DESCRIPTION
This PR adds a check-license target to the projects Makefile 
(which excludes the ./lib dir with generated go files) and adds the
license headers to the files described in YUNIKORN-128.