### PR TITLE
[YUNIKORN-397] Makefile use go version from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Check if this is at least GO tools used is at least the version of go specified in
+# Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.
 GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
 MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,22 @@
 # limitations under the License.
 #
 
-# Check if this is at least GO 1.11 for Go Modules
-GO_VERSION := $(shell go version | awk '$$3 ~ /go1.(10|0-9])/ {print $$3}')
-ifdef GO_VERSION
-$(error Build requires go 1.11 or later)
+# Check if this is at least GO tools used is at least the version of go specified in
+# the go.mod file. The version in go.mod should be in sync with other repos.
+GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
+MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
+
+GM := $(word 1,$(subst ., ,$(GO_VERSION)))
+MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
+endif
+GM := $(word 2,$(subst ., ,$(GO_VERSION)))
+MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
 
 # Retrieve the protobuf version defined in the go module, and download the same version of binary for the build

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -16,10 +16,22 @@
 # limitations under the License.
 #
 
-# Check if this is at least GO 1.11 for Go Modules
-GO_VERSION := $(shell go version | awk '$$3 ~ /go1.(10|0-9])/ {print $$3}')
-ifdef GO_VERSION
-$(error Build requires go 1.11 or later)
+# Check if this is at least GO tools used is at least the version of go specified in
+# the go.mod file. The version in go.mod should be in sync with other repos.
+GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
+MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
+
+GM := $(word 1,$(subst ., ,$(GO_VERSION)))
+MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
+endif
+GM := $(word 2,$(subst ., ,$(GO_VERSION)))
+MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
+FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
+ifdef FAIL
+$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
 
 ifndef PROTOBUF_VERSION

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Check if this is at least GO tools used is at least the version of go specified in
+# Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.
 GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
 MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -16,24 +16,6 @@
 # limitations under the License.
 #
 
-# Check if this GO tools version used is at least the version of go specified in
-# the go.mod file. The version in go.mod should be in sync with other repos.
-GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
-MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
-
-GM := $(word 1,$(subst ., ,$(GO_VERSION)))
-MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
-ifdef FAIL
-$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
-endif
-GM := $(word 2,$(subst ., ,$(GO_VERSION)))
-MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
-ifdef FAIL
-$(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
-endif
-
 ifndef PROTOBUF_VERSION
 $(error PROTOBUF_VERSION is missing)
 endif


### PR DESCRIPTION
Instead of hard coding a go version in the Makefile use the version
from the go.mod file. The build will fail if the installed tools version
is lower than the version from the go.mod file.