### PR TITLE
[YUNIKORN-114] Shallow clone of protobuf repo

### DIFF
--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -64,6 +64,7 @@ $(PROTOC):
 	stat $@ > /dev/null 2>&1
 
 # Get and install the go plug-in for protoc.
+GIT_NO_ADVICE := "-c advice.detachedHead=false"
 PROTOBUF_PKG := github.com/golang/protobuf
 PROTOC_GEN_GO := protoc-gen-go
 PROTOC_GEN_GO_PKG := $(PROTOBUF_PKG)/$(PROTOC_GEN_GO)
@@ -71,10 +72,10 @@ PROTOC_GEN_GO_SRC := src
 $(PROTOC_GEN_GO):
 	mkdir -p $(dir $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG))
 	test -d $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG)/.git || \
-		git clone https://$(PROTOBUF_PKG) $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG)
+		git clone $(GIT_NO_ADVICE) -b $(PROTOBUF_VERSION) --depth 1 https://$(PROTOBUF_PKG) $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG)
 	(cd $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG) && \
 		(test "$$(git describe --tags | head -1)" = "$(PROTOBUF_VERSION)" || \
-		(git fetch && git checkout tags/$(PROTOBUF_VERSION))))
+		(rm -rf .??* * && git clone $(GIT_NO_ADVICE) -b $(PROTOBUF_VERSION) --depth 1 https://$(PROTOBUF_PKG) .)))
 	(cd $(PROTOC_GEN_GO_SRC)/$(PROTOBUF_PKG) && \
 		go get -v -d $$(go list -f '{{ .ImportPath }}' ./...)) && \
 		go build -o $(PROTOC_BIN_DIR)/$@ $(PROTOC_GEN_GO_PKG)


### PR DESCRIPTION
Make a shallow clone of the protobuf repository of just the tag
specified in the go.mod file.
To allow changes of the version without intervention a re-clone is
triggered if needed. This does rely on a cleanup which fails if the root
of the repo contains hidden file with a single character as the name.