### PR TITLE
[YUNIKORN-826] the makefile in scheduler-interface module should not …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
 
 GM := $(word 1,$(subst ., ,$(GO_VERSION)))
 MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
+FAIL := $(shell if [ $(GM) -lt $(MM) ]; then echo MAJOR; fi)
 ifdef FAIL
 $(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
 GM := $(word 2,$(subst ., ,$(GO_VERSION)))
 MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
+FAIL := $(shell if [ $(GM) -lt $(MM) ]; then echo MINOR; fi)
 ifdef FAIL
 $(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif


### PR DESCRIPTION
…use bash-builtin "[["

### What is this PR for?
As other modules (core and k8shim) don't use such bash syntax, it would be better to make them consistent. Also, that can't work in  sh shell.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-826

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
